### PR TITLE
Add api sub-package

### DIFF
--- a/probot/api/__init__.py
+++ b/probot/api/__init__.py
@@ -1,0 +1,6 @@
+"""
+    probot/api
+    ~~~~~~~~~~
+
+    Defines the public API of the `probot` package.
+"""

--- a/probot/api/api.py
+++ b/probot/api/api.py
@@ -1,0 +1,35 @@
+"""
+    probot/api/api
+    ~~~~~~~~~~~~~~
+
+    Defines the public API for the `probot` package.
+"""
+from .. import config, errors, hints, models
+
+#: Defines the '__all__' for the API.
+ALL = [
+    'Config',
+    'Context',
+    'Event',
+    'EventHandlerResponse',
+    'HTTPException',
+    'ID',
+    'InvalidEventHandler',
+    'Probot',
+    'ProbotException',
+    'Request',
+    'Response'
+]
+
+
+# Alias common imports so framework specific packages can access them.
+Config = config.Config
+Context = models.Context
+Event = models.Event
+EventHandlerResponse = hints.EventHandlerResponse
+HTTPException = errors.HTTPException
+ID = models.ID
+InvalidEventHandler = errors.InvalidEventHandler
+ProbotException = errors.ProbotException
+Request = models.Request
+Response = models.Response


### PR DESCRIPTION
This defines the top-level package (probot) api that will be swappable
for each support HTTP framework. For example, you can imagine
the following:

```python
import probot
from probot.api import flask as probot
from probot.api import fastapi as probot
```