### PR TITLE
Refactor context

### DIFF
--- a/probot/api/api.py
+++ b/probot/api/api.py
@@ -4,7 +4,7 @@
 
     Defines the public API for the `probot` package.
 """
-from .. import config, errors, hints, models
+from .. import errors, github, hints, models
 
 #: Defines the '__all__' for the API.
 ALL = [
@@ -16,9 +16,24 @@ ALL = [
     'InvalidEventHandler',
     'Probot',
     'ProbotException',
+    'Repository',
     'Request',
     'Response',
-    'Settings'
+    'Settings',
+    'CheckRunContext',
+    'CheckSuiteContext',
+    'CreateContext',
+    'DeleteContext',
+    'ForkContext',
+    'InstallationContext',
+    'InstallationRepositoriesContext',
+    'LabelContext',
+    'PingContext',
+    'PublicContext',
+    'PullRequestContext',
+    'PushContext',
+    'ReleaseContext',
+    'RepositoryContext'
 ]
 
 
@@ -30,6 +45,22 @@ HTTPException = errors.HTTPException
 ID = models.ID
 InvalidEventHandler = errors.InvalidEventHandler
 ProbotException = errors.ProbotException
+Repository = models.Repository
 Request = models.Request
 Response = models.Response
 Settings = models.Settings
+
+CheckRunContext = models.Context[github.CheckRunEvent]
+CheckSuiteContext = models.Context[github.CheckSuiteEvent]
+CreateContext = models.Context[github.CreateEvent]
+DeleteContext = models.Context[github.DeleteEvent]
+ForkContext = models.Context[github.ForkEvent]
+InstallationContext = models.Context[github.InstallationEvent]
+InstallationRepositoriesContext = models.Context[github.InstallationRepositoriesEvent]
+LabelContext = models.Context[github.LabelEvent]
+PingContext = models.Context[github.PingEvent]
+PublicContext = models.Context[github.PublicEvent]
+PullRequestContext = models.Context[github.PullRequestEvent]
+PushContext = models.Context[github.PushEvent]
+ReleaseContext = models.Context[github.ReleaseEvent]
+RepositoryContext = models.Context[github.RepositoryEvent]

--- a/probot/api/fastapi.py
+++ b/probot/api/fastapi.py
@@ -15,8 +15,24 @@ ID = api.ID
 InvalidEventHandler = api.InvalidEventHandler
 Probot = fastapi.Probot
 ProbotException = api.ProbotException
+Repository = api.Repository
 Request = api.Request
 Response = api.Response
 Settings = api.Settings
+
+CheckRunContext = api.CheckRunContext
+CheckSuiteContext = api.CheckSuiteContext
+CreateContext = api.CreateContext
+DeleteContext = api.DeleteContext
+ForkContext = api.ForkContext
+InstallationContext = api.InstallationContext
+InstallationRepositoriesContext = api.InstallationRepositoriesContext
+LabelContext = api.LabelContext
+PingContext = api.PingContext
+PublicContext = api.PublicContext
+PullRequestContext = api.PullRequestContext
+PushContext = api.PushContext
+ReleaseContext = api.ReleaseContext
+RepositoryContext = api.RepositoryContext
 
 __all__ = api.ALL

--- a/probot/asgi/app.py
+++ b/probot/asgi/app.py
@@ -57,7 +57,7 @@ class App(base.App[adapter.ASGIAdapterT, AsyncEventHandler]):
 
         for handler in self.handlers[context.event.id]:
             handler_response = await self.process_handler(handler, context)
-            if handler_response.status_code > response.status_code:
+            if handler_response.status_code >= response.status_code:
                 response = handler_response
 
         return response

--- a/probot/base.py
+++ b/probot/base.py
@@ -100,7 +100,7 @@ class App(Generic[AdapterT, EventHandlerT],
     @staticmethod
     def create_context(event: models.EventT,
                        app_id: str,
-                       private_key: str) -> models.Context:
+                       private_key: str) -> models.ContextT:
         """
         Create context for the given webhook event.
 
@@ -221,11 +221,11 @@ class Probot(Generic[AppT, AdapterT, AdapterAppT],
                  app: Optional[AdapterAppT] = None,
                  settings: Optional[models.Settings] = None) -> None:
         if not self.app_cls:
-            raise errors.ConfigurationException('Derived Probot types must define "app_cls"')
+            raise errors.ConfigurationValueMissing('Derived Probot types must define "app_cls"')
         if not self.adapter_cls:
-            raise errors.ConfigurationException('Derived Probot types must define "adapter_cls"')
+            raise errors.ConfigurationValueMissing('Derived Probot types must define "adapter_cls"')
 
-        self.settings = settings or models.Settings()
+        self.settings = settings or models.load_settings()
         self.app = self.app_cls(self.adapter_cls(app))
         self.app.configure(self.settings)
 

--- a/probot/defaults.py
+++ b/probot/defaults.py
@@ -4,5 +4,7 @@
 
     Contains commonly used default values.
 """
+ENV_FILE = '.env'
+ENV_PREFIX = 'PROBOT_'
 METHOD = 'POST'
 PATH = '/'

--- a/probot/descriptors.py
+++ b/probot/descriptors.py
@@ -1,0 +1,28 @@
+"""
+    probot/descriptors
+    ~~~~~~~~~~~~~~~~~~
+
+    Contains descriptors used across the package.
+"""
+import functools
+
+__all__ = ['cached']
+
+
+class CachedProperty:
+    """
+    Descriptor that caches the result of a decorated function.
+    """
+
+    def __init__(self, func):
+        functools.update_wrapper(self, func)
+        self.func = func
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        result = instance.__dict__[self.func.__name__] = self.func(instance)
+        return result
+
+
+cached = CachedProperty

--- a/probot/errors.py
+++ b/probot/errors.py
@@ -36,9 +36,9 @@ class InvalidEventHandler(ProbotException):
     """
 
 
-class ConfigurationException(ProbotException):
+class SettingsException(ProbotException):
     """
-    Base class for all configuration related exceptions.
+    Base class for all settings related exceptions.
     """
 
 

--- a/probot/github.py
+++ b/probot/github.py
@@ -5,7 +5,13 @@
     Contains all GitHub specific functionality.
 """
 import ghwht
-from github import Github, GithubIntegration
+
+from github import Github, GithubIntegration, Repository
+
+# Alias PyGithub API for cleaner imports.
+Github = Github
+GithubIntegration = GithubIntegration
+Repository = Repository
 
 # Alias the ghwht API for cleaner imports.
 new_event = ghwht.new_event
@@ -14,9 +20,20 @@ ID = ghwht.ID
 Event = ghwht.Event
 EventT = ghwht.EventT
 
-# Alias PyGithub API for cleaner imports.
-Github = Github
-GithubIntegration = GithubIntegration
+CheckRunEvent = ghwht.CheckRunEvent
+CheckSuiteEvent = ghwht.CheckSuiteEvent
+CreateEvent = ghwht.CreateEvent
+DeleteEvent = ghwht.DeleteEvent
+ForkEvent = ghwht.ForkEvent
+InstallationEvent = ghwht.InstallationEvent
+InstallationRepositoriesEvent = ghwht.InstallationRepositoriesEvent
+LabelEvent = ghwht.LabelEvent
+PingEvent = ghwht.PingEvent
+PublicEvent = ghwht.PublicEvent
+PullRequestEvent = ghwht.PullRequestEvent
+PushEvent = ghwht.PushEvent
+ReleaseEvent = ghwht.ReleaseEvent
+RepositoryEvent = ghwht.RepositoryEvent
 
 
 def create_github_api(event: EventT,

--- a/probot/github.py
+++ b/probot/github.py
@@ -33,7 +33,7 @@ def create_github_api(event: EventT,
     :param private_key: Private key of the GitHub App we're running
     :return: GitHub instance
     """
-    installation_id = getattr(getattr(event, 'installation', None), 'id', None)
+    installation_id = getattr(getattr(event.payload, 'installation', None), 'id', None)
 
     if not installation_id:
         return Github()

--- a/probot/log.py
+++ b/probot/log.py
@@ -1,0 +1,13 @@
+"""
+    probot/log
+    ~~~~~~~~~~
+
+    Contains functionality for logging.
+"""
+import logging
+
+LOG = logging.getLogger(__package__)
+
+
+def get_logger(name):
+    return LOG.getChild(name)

--- a/probot/wsgi/app.py
+++ b/probot/wsgi/app.py
@@ -57,7 +57,7 @@ class App(base.App[adapter.WSGIAdapterT, SyncEventHandler]):
 
         for handler in self.handlers[context.event.id]:
             handler_response = self.process_handler(handler, context)
-            if handler_response.status_code > response.status_code:
+            if handler_response.status_code >= response.status_code:
                 response = handler_response
 
         return response


### PR DESCRIPTION
**Status:** Ready

If merged, this refactors defines and exports individual Context models for each known webhook event/payload type. As more event/payload types are defined in `ghwht`, more context types will need to be added here.